### PR TITLE
build: loosen OpenEye version spec to >=2022.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.anaconda.org/OpenEye/simple
-OpenEye-toolkits >= 2022.1
+OpenEye-toolkits >= 2022.1  # First version compatible with Python 3.10
 mmcif >= 0.70
 rcsb.utils.io >= 1.12
 rcsb.utils.multiproc >= 0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.anaconda.org/OpenEye/simple
-OpenEye-toolkits >= 2024.1.1
+OpenEye-toolkits >= 2022.1
 mmcif >= 0.70
 rcsb.utils.io >= 1.12
 rcsb.utils.multiproc >= 0.18


### PR DESCRIPTION
@aditya-pingale @piehld Per https://github.com/rcsb/py-rcsb_app_chem/pull/13#discussion_r2087630339. I haven't tested this; to test, we need to force a lower version (we can do this in tox).