### PR TITLE
V0.86 Update CactvsMoleculeFactory imports

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -76,3 +76,4 @@
 18-Aug-2025 - V0.84 Update OpenEye requirement to be `>= 2022.1.0` (`2022.1` doesn't exist)
  2-Dec-2025 - V0.85 Switch from setuptools to hatch build system;
                     Update pipelines to use python 3.12 (note that latest OpenEye (2025.1.1) only supports up to 3.12)
+16-Feb-2026 - V0.86 Update CactvsMoleculeFactory imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rcsb.utils.chem"
 description = "RCSB Python Chemical Utility Classes"
-version = "0.85"
+version = "0.86"
 readme = "README.md"
 authors = [
     { name="John Westbrook", email="john.westbrook@rcsb.org" }

--- a/rcsb/utils/chem/CactvsMoleculeFactory.py
+++ b/rcsb/utils/chem/CactvsMoleculeFactory.py
@@ -20,7 +20,10 @@ import logging
 import os
 
 from collections import defaultdict, namedtuple
-from pkg_resources import resource_filename, Requirement
+# from pkg_resources import resource_filename
+# from packaging.requirements import Requirement
+from importlib import resources
+
 
 from rcsb.utils.io.ExecUtils import ExecUtils
 from rcsb.utils.io.MarshalUtil import MarshalUtil
@@ -50,11 +53,12 @@ class CactvsMoleculeFactory(object):
         return ok
 
     def __runCactvsPython(self, molFilePath, jsonPath, aroModel="cactvs"):
-        fp = resource_filename(Requirement.parse("rcsb.utils.chem"), "rcsb/utils/chem/cactvsAnnotateMol.py")
-        logger.info("script path is %r", fp)
-        exU = ExecUtils()
-        ok = exU.run(self.__cactvsPythonInterpreterPath, [fp, molFilePath, jsonPath, aroModel])
+        with resources.as_file(resources.files("rcsb.utils.chem").joinpath("cactvsAnnotateMol.py")) as fp:
+            logger.info("script path is %r", fp)
+            exU = ExecUtils()
+            ok = exU.run(self.__cactvsPythonInterpreterPath, [fp, molFilePath, jsonPath, aroModel])
         return ok
+        # fp = resource_filename(Requirement.parse("rcsb.utils.chem"), "rcsb/utils/chem/cactvsAnnotateMol.py")
 
     def setFile(self, ccId, filePath, molFormat="mol", atomIdxD=None):
         try:

--- a/rcsb/utils/chem/CactvsMoleculeFactory.py
+++ b/rcsb/utils/chem/CactvsMoleculeFactory.py
@@ -53,7 +53,8 @@ class CactvsMoleculeFactory(object):
 
     def __runCactvsPython(self, molFilePath, jsonPath, aroModel="cactvs"):
         with resources.as_file(resources.files("rcsb.utils.chem").joinpath("cactvsAnnotateMol.py")) as fp:
-            logger.info("script path is %r", fp)
+            logger.info("script path object is %r", fp)
+            logger.info("script path is %r", str(fp))
             exU = ExecUtils()
             ok = exU.run(self.__cactvsPythonInterpreterPath, [str(fp), molFilePath, jsonPath, aroModel])
         return ok

--- a/rcsb/utils/chem/CactvsMoleculeFactory.py
+++ b/rcsb/utils/chem/CactvsMoleculeFactory.py
@@ -55,7 +55,7 @@ class CactvsMoleculeFactory(object):
         with resources.as_file(resources.files("rcsb.utils.chem").joinpath("cactvsAnnotateMol.py")) as fp:
             logger.info("script path is %r", fp)
             exU = ExecUtils()
-            ok = exU.run(self.__cactvsPythonInterpreterPath, [fp, molFilePath, jsonPath, aroModel])
+            ok = exU.run(self.__cactvsPythonInterpreterPath, [str(fp), molFilePath, jsonPath, aroModel])
         return ok
 
     def setFile(self, ccId, filePath, molFormat="mol", atomIdxD=None):

--- a/rcsb/utils/chem/CactvsMoleculeFactory.py
+++ b/rcsb/utils/chem/CactvsMoleculeFactory.py
@@ -5,6 +5,7 @@
 # Version: 0.001
 #
 # Updates:
+#   16-Feb-2026 dwp Replace deprecated pkg_resources with importlib
 #
 ##
 """
@@ -20,8 +21,6 @@ import logging
 import os
 
 from collections import defaultdict, namedtuple
-# from pkg_resources import resource_filename
-# from packaging.requirements import Requirement
 from importlib import resources
 
 
@@ -58,7 +57,6 @@ class CactvsMoleculeFactory(object):
             exU = ExecUtils()
             ok = exU.run(self.__cactvsPythonInterpreterPath, [fp, molFilePath, jsonPath, aroModel])
         return ok
-        # fp = resource_filename(Requirement.parse("rcsb.utils.chem"), "rcsb/utils/chem/cactvsAnnotateMol.py")
 
     def setFile(self, ccId, filePath, molFormat="mol", atomIdxD=None):
         try:


### PR DESCRIPTION
V0.86 Update `CactvsMoleculeFactory` imports - replace deprecated `pkg_resources` with `importlib`